### PR TITLE
fix: disable version decoration on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,6 @@ jobs:
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true
         env:
+          DISABLE_VERSION_DECORATION: true
           AWS_ACCESS_KEY_ID: ${{ secrets.GC_AWS_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.GC_AWS_KEY }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn.build=6
 loader.version=0.11.3
 
 # Mod Info
-mod.version=0.2.0
+mod.version=0.2.1
 mod.group=dev.galacticraft
 mod.name=GalacticraftEnergy
 


### PR DESCRIPTION
* Adds the `DISABLE_VERSION_DECORATION` env var to the publish workflow
* Bumps the version to 0.2.1